### PR TITLE
Added a command and a keyboard shortcut to go from repo to parent directory

### DIFF
--- a/keymaps/tree-view-git-projects.cson
+++ b/keymaps/tree-view-git-projects.cson
@@ -1,0 +1,2 @@
+'.tree-view':
+    'escape': 'tree-view-git-projects:upper-directory'

--- a/lib/tree-view-git-projects.coffee
+++ b/lib/tree-view-git-projects.coffee
@@ -10,6 +10,7 @@ module.exports =
             if directory and directory isnt atom.project.getPaths()[0]
               atom.project.setPaths [directory]
             atom.packages.getActivePackage('tree-view')?.mainModule?.treeView?.revealActiveFile?()
+    atom.commands.add 'atom-workspace', 'tree-view-git-projects:upper-directory', => @upperDirectory()
   gitDirectory: (directory, callback) ->
     directory = directory.replace /[^\\\/]*[\\\/]?$/i, ''
     if directory
@@ -20,3 +21,6 @@ module.exports =
           @gitDirectory directory, callback
     else
       callback ''
+  upperDirectory: ->
+    up = path.dirname atom.project.getPaths()[0]
+    atom.project.setPaths [up]

--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
   "license": "Public Domain <Unlicense.org>",
   "engines": {
     "atom": ">0.50.0"
-  }
+  },
+  "activationEvents": ["tree-view-git-projects:upper-directory"]
 }


### PR DESCRIPTION
This package is a great idea!
Especially considering the current lack of proper project management features in atom.

One thing was bothering me: how can I escape a git repository once I've focused a file in it?
So I've added a command, called "tree-view-git-projects:upper-directory" which navigates to the parent directory of the current working directory.
There is also a keyboard shortcut, "escape", that triggers the command when the tree-view is focused.
